### PR TITLE
Fix HLS (YouTube) by adding network-status plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,7 +24,7 @@ platforms:
 apps:
   uxplay:
     extensions: [ gnome ]
-    plugs: [ audio-playback, avahi-control, network, network-bind, opengl, wayland ]
+    plugs: [ audio-playback, avahi-control, network, network-bind, network-status, opengl, wayland ]
     # daemon: simple
     # daemon-scope: user
     environment:


### PR DESCRIPTION
In order for HLS (e.g. YouTube playback from iOS) to work on the snapped version of uxplay, the `network-status` plug needs to be added. Otherwise you'll get the following vague error:
```
GStreamer error (video): source Internal data stream error.
GStreamer error (video): typefindelement2 Stream doesn't contain enough data.
```

Poking around the web, I found that other people encountered some similar errors and attributed it to GStreamer testing for internet connectivity behind the scenes. I tried adding the `network-status` plug and it :sparkles: just works :sparkles: . Luckily `network-status` is an autoconnect plug so no changes to the installation process are needed.

I tested this on both the current uxplay snapped here (v1.72.2) and the latest build (v1.73.3).

NOTE: In order to use hls I have to use the v2 version (`uxplay -hls 2`) not the default v3, but that is not specific to this snap -- the same occurs with the plain-ol upstream repo as well.